### PR TITLE
Fixing broken links

### DIFF
--- a/src/routes/about.html
+++ b/src/routes/about.html
@@ -4,7 +4,7 @@
 
 <h1>About this site</h1>
 
-<p>Hacker News clones are the new TodoMVC. <a href='https://vue-hn.now.sh'>Vue</a> has one, <a href='https://next-news.now.sh'>Next</a> has one, <a href='https://react-hn.appspot.com'>React</a> and <a href='https://preact-hn.appspot.com'>Preact</a> have theirs. And now, Svelte has one.</p>
+<p>Hacker News clones are the new TodoMVC. <a href='https://vue-hn.herokuapp.com'>Vue</a> has one, <a href='https://next-news.now.sh'>Next</a> has one, <a href='https://react-hn.appspot.com'>React</a> and <a href='https://developit.github.io/hn_minimal/'>Preact</a> have theirs. And now, Svelte has one.</p>
 
 <p>Svelte is a new kind of framework, one that compiles your component templates into fast, compact JavaScript — either client-side or server-side. You can read more about the design and philosophy in the <a href='https://svelte.technology/blog/frameworks-without-the-framework/'>introductory blog post</a>.</p>
 


### PR DESCRIPTION
The links to Vue, React and Preact apps are dead. I found working ones for Vue and Preact.